### PR TITLE
add notes in makefile and git2rss to fix errors encountered

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ serve:
 #   push: rsync
 #   push: gh-pages
 
-push:
+push: "add/one/of/the/two/items/here"
 
 ########################################
 # IF you're going to publish the generated book to a web server, and you're
@@ -38,6 +38,9 @@ rsync: build
 # NOTES:
 # - These commands work for me using bash. If you're using some other shell,
 #   you may need to adjust or remove this line.
+# - For example, if you see the error `/bin/sh: 8: pushd: not found`, that means
+#	the `pushd` command is not available in your shell. 
+#	In that case, replace in the block below `pushd` and `popd` with `cd` and `cd -` respectively
 # - The 'git worktree' commands require git version 2.0.7 or later.
 
 gh-pages: build

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ rsync: build
 #
 # NOTES:
 # - These commands work for me using bash. If you're using some other shell,
-#   you may need to adjust or remove this line. See *Troubleshoot* in README.
+#   You may need to adjust or remove this line. See *Troubleshoot* in README.
 
 gh-pages: build
 	set -ex ; \

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,7 @@ rsync: build
 #
 # NOTES:
 # - These commands work for me using bash. If you're using some other shell,
-#   you may need to adjust or remove this line.
-# - For example, if you see the error `/bin/sh: 8: pushd: not found`, that means
-#	the `pushd` command is not available in your shell. 
-#	In that case, replace in the block below `pushd` and `popd` with `cd` and `cd -` respectively
-# - The 'git worktree' commands require git version 2.0.7 or later.
+#   you may need to adjust or remove this line. See *Troubleshoot* in README.
 
 gh-pages: build
 	set -ex ; \

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ serve:
 #   push: rsync
 #   push: gh-pages
 
-push: "add/one/of/the/two/items/here"
+push:
 
 ########################################
 # IF you're going to publish the generated book to a web server, and you're

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ $ make push
 
 If you're totally finished, go back to "Window 1" where the `make serve` command is still running, and hit CTRL-C to stop it.
 
-# Troublshoot
+# Troubleshoot
 
 ## pushd unavailable in shell
 If you see this error: 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,17 @@ $ make push
 
 If you're totally finished, go back to "Window 1" where the `make serve` command is still running, and hit CTRL-C to stop it.
 
+# Troublshoot
+
+## pushd unavailable in shell
+If you see this error: 
+```
+/bin/sh: 8: pushd: not found
+```
+
+That means the `pushd` command is unavailable in your shell (e.g. dash). 
+In this case, in the Makefile, replace `pushd` and `popd` in the block at the end of the page with `cd` and `cd -` respectively.
+
 # Background
 
 This section will explain the customizations I'm making to how `mdbook` formats its output.

--- a/git2rss
+++ b/git2rss
@@ -1,5 +1,15 @@
 #!/usr/bin/env perl -w
-#
+# 
+# Notes::
+# If you see the error `/usr/bin/env: ‘perl -w’: No such file or directory
+# /usr/bin/env: use -[v]S to pass options in shebang lines`
+# that means there is an issue with how the Perl interpreter is being invoked 
+# in the `git2rss` script.
+# To fix this, simply  removes the `-w` flag from the shebang
+# i.e, replace the first line with `this:
+# !/usr/bin/env perl
+# and save and run the build again.
+# 
 # git2rss
 # John Simpson <jms1@jms1.net> 2023-07-25
 #


### PR DESCRIPTION
The PR simply adds notes on how to fix a couple of errors:

1. error encountered related to the use of Perl in the `git2rss` script. Specifically, the error message:
```
/usr/bin/env: ‘perl -w’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```

2. error encountered when `pushd` command is not available in shell. Specifically, the error message:
`/bin/sh: 8: pushd: not found`